### PR TITLE
handle __str__ like it should

### DIFF
--- a/datajob/datajob_base.py
+++ b/datajob/datajob_base.py
@@ -70,4 +70,4 @@ class DataJobBase(core.Construct):
         return f"{self}"
 
     def __str__(self):
-        return f"{self}"
+        return f"type: {type(self)} with name : {self.name}"


### PR DESCRIPTION
- bad practice to print the object self in __str__, this leads to recursion
- closes #98 
