### PR TITLE
update workflow continuously

### DIFF
--- a/datajob/stepfunctions/stepfunctions_workflow.py
+++ b/datajob/stepfunctions/stepfunctions_workflow.py
@@ -135,7 +135,7 @@ class StepfunctionsWorkflow(DataJobBase):
                 self.chain_of_tasks.append(sfn_task)
         return self.chain_of_tasks
 
-    def _build_workflow(self):
+    def build_workflow(self):
         """create a step functions workflow from the chain_of_tasks."""
         self.chain_of_tasks = self._construct_toposorted_chain_of_tasks()
         logger.debug("creating a chain from all the different steps.")
@@ -226,7 +226,6 @@ class StepfunctionsWorkflow(DataJobBase):
 
     def __exit__(self, exc_type, exc_value, traceback) -> None:
         """steps we have to do when exiting the context manager."""
-        self._build_workflow()
         _set_workflow(None)
         logger.info(f"step functions workflow {self.unique_name} created")
 
@@ -258,7 +257,7 @@ def task(self):
 
         Syntactic suggar for >>.
         """
-        _connect(self=self, other=other)
+        connect(self=self, other=other)
         return other
 
     setattr(self, "__rshift__", __rshift__)
@@ -276,6 +275,7 @@ def _get_workflow():
         return None
 
 
-def _connect(self, other: DataJobBase) -> None:
+def connect(self, other: DataJobBase) -> None:
     work_flow = _get_workflow()
     work_flow.directed_graph[other].add(self)
+    work_flow.build_workflow()

--- a/datajob_tests/stepfunctions/test_stepfunctions_workflow.py
+++ b/datajob_tests/stepfunctions/test_stepfunctions_workflow.py
@@ -158,3 +158,46 @@ class TestStepfunctionsWorkflow(unittest.TestCase):
         self.assertEqual(
             sfn_workflow.get("States").get("notification").get("Type"), "Parallel"
         )
+
+    @mock_stepfunctions
+    def test_update_stepfunctions_continuously(self):
+        """update the workflow continuously instead of waiting all the way in
+        the end.
+
+        test written based on ticket
+        https://github.com/vincentclaes/datajob/issues/116
+        """
+
+        task1 = stepfunctions_workflow.task(SomeMockedClass("task1"))
+        task2 = stepfunctions_workflow.task(SomeMockedClass("task2"))
+        task3 = stepfunctions_workflow.task(SomeMockedClass("task3"))
+
+        djs = DataJobStack(
+            scope=self.app,
+            id="a-unique-name-1",
+            stage="stage",
+            project_root="sampleproject/",
+            region="eu-west-1",
+            account="3098726354",
+        )
+        with StepfunctionsWorkflow(djs, "some-name") as a_step_functions_workflow:
+            self.assertIsNone(a_step_functions_workflow.workflow)
+            self.assertIsNone(a_step_functions_workflow.chain_of_tasks)
+            task1 >> task2
+            self.assertIsNotNone(a_step_functions_workflow.workflow)
+            self.assertEqual(len(a_step_functions_workflow.chain_of_tasks.steps), 2)
+            task2 >> task3
+            self.assertEqual(len(a_step_functions_workflow.chain_of_tasks.steps), 3)
+
+        expected_workflow_definition = {
+            "StartAt": "task1",
+            "States": {
+                "task1": {"Type": "Task", "Next": "task2"},
+                "task2": {"Type": "Task", "Next": "task3"},
+                "task3": {"Type": "Task", "End": True},
+            },
+        }
+        self.assertEqual(
+            a_step_functions_workflow.workflow.definition.to_dict(),
+            expected_workflow_definition,
+        )


### PR DESCRIPTION
- build workflow continuously
- allows user to manipulate workflow without exiting context manager
- closes #116 