### PR TITLE
added creation of the output stacks

### DIFF
--- a/datajob/datajob_stack.py
+++ b/datajob/datajob_stack.py
@@ -140,6 +140,7 @@ class DataJobStack(core.Stack):
             for resource in self.resources:
                 logger.debug(f"creating resource: {resource.name}")
                 resource.create()
+        self.create_cloudformation_outputs()
         logger.debug("no resources available to create.")
 
     def get_stage(self, stage: str) -> Union[str, None]:


### PR DESCRIPTION
The execution inputs are read from the cloudformation stacks output.
At the moment the cloudformation stack outputs are not created.

This PR reintroduces the step of creation of the outputs which is needed to have a good execution when Sagemaker steps are present